### PR TITLE
Add support for Consul TTLs and multiple checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Overall refactoring and cleanup
 - Decoupled registries into subpackages using extpoints
+- Add full TTL support for Consul 0.5.0.
+- Support multiple Consul checks per service (such as a TTL and script)
 
 
 ## [v5] - 2015-02-18

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If the argument `-internal` is passed, registrator will register the docker0 int
 
 The `-resync` argument controls how often registrator will query Docker for all containers and reregister all services.  This allows registrator and the service registry to get back in sync if they fall out of sync.  The time is measured in seconds, and if set to zero will not resync.
 
-The consul backend does not support automatic expiry of stale registrations after some TTL. Instead, TTL checks must be configured (see below). For backends that do support TTL expiry, registrator can be started with the `-ttl` and `-ttl-refresh` arguments (both disabled by default).
+For backends that support TTL expiry, registrator can be started with the `-ttl` and `-ttl-refresh` arguments (both disabled by default).
 
 ### Host mode services
 
@@ -219,7 +219,7 @@ Then add a factory which accepts a uri and returns the registry adapter, and reg
 
 > All health checking integration is going to change soon, so consider these features deprecated.
 
-When using the Consul's service catalog backend, you can specify a health check associated with a service. Registrator can pull this from your container environment data if provided. Here are some examples:
+When using the Consul's service catalog backend, you can specify several health check to be associated with a service. Registrator can pull this from your container environment data if provided. Here are some examples:
 
 #### Basic HTTP health check
 

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -1,0 +1,88 @@
+package consul
+
+import (
+	"testing"
+
+	"github.com/gliderlabs/registrator/bridge"
+)
+
+func TestBuildChecksInOrder(t *testing.T) {
+	service := service()
+	service.Attrs["check_http"] = "/test"
+	service.Attrs["check_cmd"] = "echo 1"
+	service.Attrs["check_ttl"] = "30s"
+	service.Attrs["check_script"] = "some script"
+
+	checks := new(ConsulAdapter).buildChecks(service)
+	if checks[0].Script != "check-cmd 123456789012 1 echo 1" {
+		t.Error("Expected check-cmd but got", checks[0])
+	} else if checks[1].Script != "check-http 123456789012 1 /test" {
+		t.Error("Expected check-http but got", checks[1])
+	} else if checks[2].Script != "some script" {
+		t.Error("Expected check script but got", checks[2])
+	} else if checks[3].TTL != "30s" {
+		t.Error("Expected TTL but got", checks[3])
+	}
+}
+
+func TestBuildChecksInterpolates(t *testing.T) {
+	service := service()
+	service.Attrs["check_script"] = "$SERVICE_IP:$SERVICE_PORT"
+
+	script := new(ConsulAdapter).buildChecks(service)[0].Script
+	if script != "127.0.0.1:10" {
+		t.Error("Unexpected result,", script)
+	}
+}
+
+func TestIntervalSpecification(t *testing.T) {
+	service := service()
+	service.Attrs["check_interval"] = "15s"
+	service.Attrs["check_script"] = "something"
+
+	interval := new(ConsulAdapter).buildChecks(service)[0].Interval
+	if interval != "15s" {
+		t.Error("Unexpected result,", interval)
+	}
+}
+
+func TestRefreshOnlyTTL(t *testing.T) {
+	service := service()
+	service.Attrs["check_ttl"] = "30s"
+	service.Attrs["check_interval"] = "25s"
+	verifyTTLCall(t, service, "service:tests")
+}
+
+func TestRefreshMultipleChecks(t *testing.T) {
+	service := service()
+	service.Attrs["check_script"] = "something"
+	service.Attrs["check_ttl"] = "30s"
+	verifyTTLCall(t, service, "service:tests:2")
+}
+
+func verifyTTLCall(t *testing.T, service *bridge.Service, expected string) {
+	callCheck := ""
+	callNotes := ""
+	adapter := ConsulAdapter{}
+	adapter.refresh(service, func(check string, notes string) error {
+		callCheck = check
+		callNotes = notes
+		return nil
+	})
+	if callCheck != expected {
+		t.Error("Actual service check called:", callCheck)
+	} else if callNotes == "" {
+		t.Error("No notes passed.")
+	}
+}
+
+func service() *bridge.Service {
+	service := new(bridge.Service)
+	service.ID = "tests"
+	service.Origin.ExposedPort = "1"
+	service.Origin.ContainerID = "1234567890123"
+	service.Origin.HostIP = "127.0.0.1"
+	service.Origin.HostPort = "10"
+	service.Attrs = make(map[string]string)
+	return service
+}


### PR DESCRIPTION
This may potentially close #57, depending on how the original author wishes to
solve the problem. On each refresh, Registrator will write the current timestamp
into the check's notes.

Further, this change also introduces the ability to have multiple health checks
types. For example, a TTL may be used in conjunction with a script. This allows
for a more reliable service discovery mechanism, reducing the risk of services
reclaiming old ports. These changes also open the door for a simple, native HTTP
check integration with Consul. Because Registrator doesn't currently have an API
to store the upstream state of the service (i.e. remote check IDs), the Consul
adapter filters the defined checks into an ordered list, which it then
correlates to the check ID in Consul based on index. Consul's API implementation
suggests this is safe, however, this behaviour is not documented.

Sadly, this breaks compatibility with Consul 0.4.x, which only supported one
service check per service.